### PR TITLE
Re-number bounties and add Discussion links

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To indicate interest in a bounty, self-test for basic eligibility, and get an em
 The following bounties are available for anyone to pick up:
 
 - [JavaScript Code Samples](https://github.com/XRPLBounties/Proposals/blob/main/bounties/0031%20JavaScript%20Code%20Samples.md)
-- [Python code samples](https://github.com/XRPLBounties/Proposals/blob/main/bounties/1%20Python%20code%20samples.md)
+- [Python Code Samples](https://github.com/XRPLBounties/Proposals/blob/main/bounties/0032%20Python%20Code%20Samples.md)
 - [Ledger Metrics](https://github.com/XRPLBounties/Proposals/blob/main/bounties/2%20Ledger%20Metrics.md)
 - [Code-Plugin for Unity Game Engine](https://github.com/XRPLBounties/Proposals/blob/main/bounties/3%20Code-Plugin%20for%20Unity%20Game%20Engine.md)
 - [Unreal Engine 5 Integration](https://github.com/XRPLBounties/Proposals/blob/main/bounties/4%20Unreal%20Engine%205%20Integration.md)

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The following bounties are available for anyone to pick up:
 
 - [JavaScript Code Samples](https://github.com/XRPLBounties/Proposals/blob/main/bounties/0031%20JavaScript%20Code%20Samples.md)
 - [Python Code Samples](https://github.com/XRPLBounties/Proposals/blob/main/bounties/0032%20Python%20Code%20Samples.md)
-- [Ledger Metrics](https://github.com/XRPLBounties/Proposals/blob/main/bounties/2%20Ledger%20Metrics.md)
+- [Ledger Metrics](https://github.com/XRPLBounties/Proposals/blob/main/bounties/0018%20Ledger%20Metrics.md)
 - [Code-Plugin for Unity Game Engine](https://github.com/XRPLBounties/Proposals/blob/main/bounties/3%20Code-Plugin%20for%20Unity%20Game%20Engine.md)
 - [Unreal Engine 5 Integration](https://github.com/XRPLBounties/Proposals/blob/main/bounties/4%20Unreal%20Engine%205%20Integration.md)
 - [Proof of Attendance Infrastructure](https://github.com/XRPLBounties/Proposals/blob/main/bounties/5%20Proof%20of%20Attendance%20Infrastructure.md)

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ The following bounties are available for anyone to pick up:
 - [JavaScript Code Samples](https://github.com/XRPLBounties/Proposals/blob/main/bounties/0031%20JavaScript%20Code%20Samples.md)
 - [Python Code Samples](https://github.com/XRPLBounties/Proposals/blob/main/bounties/0032%20Python%20Code%20Samples.md)
 - [Ledger Metrics](https://github.com/XRPLBounties/Proposals/blob/main/bounties/0018%20Ledger%20Metrics.md)
-- [Code-Plugin for Unity Game Engine](https://github.com/XRPLBounties/Proposals/blob/main/bounties/3%20Code-Plugin%20for%20Unity%20Game%20Engine.md)
-- [Unreal Engine 5 Integration](https://github.com/XRPLBounties/Proposals/blob/main/bounties/4%20Unreal%20Engine%205%20Integration.md)
-- [Proof of Attendance Infrastructure](https://github.com/XRPLBounties/Proposals/blob/main/bounties/5%20Proof%20of%20Attendance%20Infrastructure.md)
+- [Code-Plugin for Unity Game Engine](https://github.com/XRPLBounties/Proposals/blob/main/bounties/0015%20Code-Plugin%20for%20Unity%20Game%20Engine.md)
+- [Unreal Engine 5 Integration](https://github.com/XRPLBounties/Proposals/blob/main/bounties/0014%20Unreal%20Engine%205%20Integration.md)
+- [Proof of Attendance Infrastructure](https://github.com/XRPLBounties/Proposals/blob/main/bounties/0019%20Proof%20of%20Attendance%20Infrastructure.md)
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To indicate interest in a bounty, self-test for basic eligibility, and get an em
 
 The following bounties are available for anyone to pick up:
 
-- [JavaScript code samples](https://github.com/XRPLBounties/Proposals/blob/main/bounties/0%20JavaScript%20code%20samples.md)
+- [JavaScript Code Samples](https://github.com/XRPLBounties/Proposals/blob/main/bounties/0031%20JavaScript%20Code%20Samples.md)
 - [Python code samples](https://github.com/XRPLBounties/Proposals/blob/main/bounties/1%20Python%20code%20samples.md)
 - [Ledger Metrics](https://github.com/XRPLBounties/Proposals/blob/main/bounties/2%20Ledger%20Metrics.md)
 - [Code-Plugin for Unity Game Engine](https://github.com/XRPLBounties/Proposals/blob/main/bounties/3%20Code-Plugin%20for%20Unity%20Game%20Engine.md)

--- a/bounties/0014 Unreal Engine 5 Integration.md
+++ b/bounties/0014 Unreal Engine 5 Integration.md
@@ -1,10 +1,16 @@
+---
+ID: "0014"
+Discussion: https://github.com/XRPLBounties/Proposals/discussions/0014
+Category: Game Development
+Status: Open
+Amount: $3,000
+---
+
 # Unreal Engine 5 Integration
 
 ## High Level Description
 
 Description: Build a code-plugin for Unreal Engine 5 that allows game developers to make payments using the XRPL, and trade NFTs.
-
-Amount: $3,000
 
 ### Full Description
 

--- a/bounties/0015 Code-Plugin for Unity Game Engine.md
+++ b/bounties/0015 Code-Plugin for Unity Game Engine.md
@@ -1,8 +1,12 @@
+---
+ID: "0015"
+Discussion: https://github.com/XRPLBounties/Proposals/discussions/0015
+Category: Game Development
+Status: Open
+Amount: $5,000
+---
+
 # Code-Plugin for Unity Game Engine
-
-**Category:** Game Development
-
-**Proposed Amount:** $5,000
 
 ## Overview
 

--- a/bounties/0018 Ledger Metrics.md
+++ b/bounties/0018 Ledger Metrics.md
@@ -1,7 +1,7 @@
 ---
 ID: "0018"
 Discussion: https://github.com/XRPLBounties/Proposals/discussions/0018
-Category: Technical Documentation
+Category: New Feature
 Status: Open
 Amount: $3,000
 ---

--- a/bounties/0018 Ledger Metrics.md
+++ b/bounties/0018 Ledger Metrics.md
@@ -1,8 +1,12 @@
+---
+ID: "0018"
+Discussion: https://github.com/XRPLBounties/Proposals/discussions/0018
+Category: Technical Documentation
+Status: Open
+Amount: $3,000
+---
+
 # Ledger Metrics
-
-**Category:** Technical Documentation
-
-**Proposed Amount:** $3,000
 
 ## Overview
 When viewing a particular ledger (e.g. [Ledger Page](https://livenet.xrpl.org/ledgers/69537171)) in addition to showing a table of transaction a collection of metrics for the ledger should be show.
@@ -17,9 +21,9 @@ The following metrics should be shown above the transaction table and accompanie
 	- Number of successful transactions
 	- Number of failed transactions (tec*)
 	- Breakdown of transactions by type (DEX, Payments, Account, NFT, XChain)
-	- A special call out (icon) if there are no tecINVARIANT_FAILED transactions
+	- A special call-out (icon) if there are no `tecINVARIANT_FAILED` transactions
 - Milestone 2 Stats
-	- Summaries of the amount of ledger objects by type (Accounts, Offers, Escrows, TrustLines, Paychannel, etc.)
+	- Summaries of the amount of [ledger objects by type](https://xrpl.org/ledger-object-types.html): AccountRoot (account), Offer, Escrow, RippleState (trust line), PayChannel, etc.
 	
 ### Proposed Visuals
 The new data should follow the design below.  It shows what it would look like with the current metrics.  The new metrics would use the same styling

--- a/bounties/0019 Proof of Attendance Infrastructure.md
+++ b/bounties/0019 Proof of Attendance Infrastructure.md
@@ -1,12 +1,16 @@
+---
+ID: "0019"
+Discussion: https://github.com/XRPLBounties/Proposals/discussions/0019
+Category: New Feature
+Status: Open
+Amount: $6,000
+---
+
 # Proof of Attendance Infrastructure
-
-**Category:** New Feature/ Community Event Management Tool
-
-**Proposed Amount:** $6,000
 
 ## Overview
 
-Build a library to provide infrastructure that allows event organizers to mint and distribute Attendance NFTs on the XRP Ledger.
+Community Event Management Tool: Build a library to provide infrastructure that allows event organizers to mint and distribute Attendance NFTs on the XRP Ledger.
 
 ## Details
 

--- a/bounties/0031 JavaScript Code Samples.md
+++ b/bounties/0031 JavaScript Code Samples.md
@@ -1,5 +1,5 @@
 ---
-ID: 0031
+ID: "0031"
 Discussion: https://github.com/XRPLBounties/Proposals/discussions/0031
 Category: Technical Documentation
 Status: Open

--- a/bounties/0031 JavaScript Code Samples.md
+++ b/bounties/0031 JavaScript Code Samples.md
@@ -1,8 +1,12 @@
-# JavaScript code samples
+---
+ID: 0031
+Discussion: https://github.com/XRPLBounties/Proposals/discussions/0031
+Category: Technical Documentation
+Status: Open
+Amount: $2,000
+---
 
-**Category:** Technical Documentation
-
-**Amount:** $2,000
+# JavaScript Code Samples
 
 ## Overview
 

--- a/bounties/0032 Python Code Samples.md
+++ b/bounties/0032 Python Code Samples.md
@@ -1,8 +1,12 @@
-# Python code samples
+---
+ID: "0032"
+Discussion: https://github.com/XRPLBounties/Proposals/discussions/0032
+Category: Technical Documentation
+Status: Open
+Amount: $7,500
+---
 
-**Category:** Technical Documentation
-
-**Proposed Amount:** $7,500
+# Python Code Samples
 
 ## Overview
 


### PR DESCRIPTION
This adds a **Discussion** link in a table near the top of each bounty, and re-numbers them to re-use the Discussion # as the ID # for the bounty. The number is not a counter for the number of bounties, but just a unique identifier. So in the future, we could refer to bounty-0019 (for example) as a shorthand. You could then plug in 0019 in the URL, like `https://github.com/XRPLBounties/Proposals/discussions/0019`, to easily see which bounty the number refers to.