### PR TITLE
Clarify requirements for code snippet bounties

### DIFF
--- a/bounties/0031 JavaScript Code Samples.md
+++ b/bounties/0031 JavaScript Code Samples.md
@@ -25,6 +25,9 @@ https://xrpl.org/code-samples.html
 | 1 | [Cryptographic Key Derivation](https://github.com/XRPLF/xrpl-dev-portal/tree/master/content/_code-samples/key-derivation) | Derive secp256k1 or Ed25519 key pairs from seeds in any of the XRP Ledger's encodings and formats. This sample can be pulled out of, or perhaps implemented within, an existing client library. | $1,000 |
 | 2 | [Transaction Serialization](https://github.com/XRPLF/xrpl-dev-portal/tree/master/content/_code-samples/tx-serialization) |  This sample can be pulled out of, or perhaps implemented within, an existing client library. | $1,000 |
 
+When creating a PR to add these code samples please include a link to this document: 
+https://github.com/XRPLBounties/Proposals/blob/main/bounties/0031%20JavaScript%20Code%20Samples.md
+
 ➡️ A milestone is complete only after the relevant code sample has been approved, merged, and deployed onto XRPL.org.
 - All of these code samples must have feature parity with the existing equivalent code samples in other languages. 
 - They must also be well-documented to be a useful learning reference, not just working code which performs the task.

--- a/bounties/0031 JavaScript Code Samples.md
+++ b/bounties/0031 JavaScript Code Samples.md
@@ -26,5 +26,7 @@ https://xrpl.org/code-samples.html
 | 2 | [Transaction Serialization](https://github.com/XRPLF/xrpl-dev-portal/tree/master/content/_code-samples/tx-serialization) |  This sample can be pulled out of, or perhaps implemented within, an existing client library. | $1,000 |
 
 ➡️ A milestone is complete only after the relevant code sample has been approved, merged, and deployed onto XRPL.org.
+- All of these code samples must have feature parity with the existing equivalent code samples in other languages. 
+- They must also be well-documented to be a useful learning reference, not just working code which performs the task.
 
 **Ripple internal ID:** DGE-94

--- a/bounties/0032 Python Code Samples.md
+++ b/bounties/0032 Python Code Samples.md
@@ -31,6 +31,8 @@ https://xrpl.org/code-samples.html
 | 7 | [Tickets](https://github.com/XRPLF/xrpl-dev-portal/tree/master/content/_code-samples/use-tickets) | Create a Ticket and use it to send a transaction out of the usual Sequence order. | $1,000 |
 | 8 | [Use Checks](https://github.com/XRPLF/xrpl-dev-portal/tree/master/content/_code-samples/checks) | Create, cash, and cancel Checks for exact or flexible amounts. | $1,000 |
 
-A milestone is complete only after the relevant code sample has been approved, merged, and deployed onto XRPL.org.
+- A milestone is complete only after the relevant code sample has been approved, merged, and deployed onto XRPL.org.
+- All of these code samples must have feature parity with the existing equivalent code samples in other languages. 
+- They must also be well-documented to be a useful learning reference, not just working code which performs the task.
 
 **Ripple internal ID:** DGE-93

--- a/bounties/0032 Python Code Samples.md
+++ b/bounties/0032 Python Code Samples.md
@@ -31,6 +31,9 @@ https://xrpl.org/code-samples.html
 | 7 | [Tickets](https://github.com/XRPLF/xrpl-dev-portal/tree/master/content/_code-samples/use-tickets) | Create a Ticket and use it to send a transaction out of the usual Sequence order. | $1,000 |
 | 8 | [Use Checks](https://github.com/XRPLF/xrpl-dev-portal/tree/master/content/_code-samples/checks) | Create, cash, and cancel Checks for exact or flexible amounts. | $1,000 |
 
+When submitting a PR completing one of these milestones, please link to this markdown file for the bounty:
+https://github.com/XRPLBounties/Proposals/blob/main/bounties/0032%20Python%20Code%20Samples.md
+
 - A milestone is complete only after the relevant code sample has been approved, merged, and deployed onto XRPL.org.
 - All of these code samples must have feature parity with the existing equivalent code samples in other languages. 
 - They must also be well-documented to be a useful learning reference, not just working code which performs the task.


### PR DESCRIPTION
This will make it easier for reviewers to know exactly which bounty the contribution is for, and clarifies that the code snippets need to have feature parity + be well-documented to help new readers learn how the feature works.