### PR TITLE
Make the email contact more visible

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,5 @@ XRPL Bounties expresses sincere gratitude to all of the contributors who help to
 
 - See other people's ideas for bounties: https://github.com/XRPLBounties/Proposals/discussions
 - Share an idea for a bounty: https://github.com/XRPLBounties/Proposals/discussions/new?category=ideas
+
+## If you have questions, please send them to info@xrplbounties.org (We will aim to respond within 2-3 business days)


### PR DESCRIPTION
Based on feedback that a contributor didn't know where to ask questions, we should make the email more visible on the page.