### PR TITLE
Remove requirement for multiple NFT required for a single gate

### DIFF
--- a/open_bounties/0052 Shopify NFT App.md
+++ b/open_bounties/0052 Shopify NFT App.md
@@ -62,7 +62,6 @@ Merchant dashboard features
   - [ ] selection for NFTs used in the campaign to act as the gate; as the merchant will likely be minting NFTs for other purposes, we want to allow the merchant to select which specific NFTs will be used for this campaign
   - [ ] associate reward/promo for NFT(s) such as discount, BOGO and/or free product
   - [ ] selection of included products or collections to which the promo applies, as the merchant will likely have products they don't want discounted
-  - [ ] specific qualifying conditions (ie. must have 3 specific NFTs); some products might be special and require 2 or more NFTs to unlock promo
 
 Merchant storefront features
 - [ ] display widget via [Shopify app theme extension](https://shopify.dev/apps/online-store/theme-app-extensions) to connect wallet


### PR DESCRIPTION
After discussion with @jiveyTO this requirement doesn't actually seem necessary for a useful standalone Shopify app. Most campaigns will only need one NFT to gate a discount behind, and it can complicate the UI negatively impacting user experience. So, we thought it'd be worth removing this requirement from milestone 1.
